### PR TITLE
Bug-fix: Timestamp in the "RUN" record is interpreted as milliseconds.

### DIFF
--- a/src/clojider_gatling_highcharts_reporter/reporter.clj
+++ b/src/clojider_gatling_highcharts_reporter/reporter.clj
@@ -26,7 +26,7 @@
     (concat [scenario-start] requests [scenario-end])))
 
 (defn gatling-csv-lines [start-time simulation idx results]
-  (let [timestamp (unparse-local (formatter "yyyyMMddhhmmss") start-time)
+  (let [timestamp (-> start-time .toDateTime .getMillis str)
         header ["clj-gatling" (:name simulation) "RUN" timestamp "\u0020" "2.0"]]
     (conj (flatten-one-level (mapcat #(vector (scenario->rows %)) results)) header)))
 


### PR DESCRIPTION
In the generated index.html the `timestamp` is interpreted as milliseconds,
thus when the `yyyyMMddhhmmss`-value is parsed, it's way off into the future.

For example:

    var timestamp = 20210108123520;
    var runStartHumanDate = moment(timestamp).format("YYYY-MM-DD HH:mm:ss Z");
    document.writeln("<p class='sim_desc' title='"+ runStartHumanDate +", duration : -18600005999 seconds' data-content=''>");
    document.writeln("<b>" + runStartHumanDate + ", duration : -18600005999 seconds </b>");

However, the following is correct when it is milliseconds:

    var timestamp = 1610115553444;
    var runStartHumanDate = moment(timestamp).format("YYYY-MM-DD HH:mm:ss Z");
    document.writeln("<p class='sim_desc' title='"+ runStartHumanDate +", duration : 15 seconds' data-content=''>");
    document.writeln("<b>" + runStartHumanDate + ", duration : 15 seconds </b>");