### PR TITLE
Add support for KO error messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojider-gatling-highcharts-reporter "0.3.1"
+(defproject clojider-gatling-highcharts-reporter "0.3.2"
   :description "Gatling Highcharts Reporter for clj-gatling"
   :url "https://github.com/mhjort/clojider-gatling-highcharts-reporter"
   :license {:name "Eclipse Public License"
@@ -12,4 +12,4 @@
                                net.sf.saxon/Saxon-HE]]
                  [io.gatling.highcharts/gatling-charts-highcharts "2.0.3"
                   :exclusions [io.gatling/gatling-app io.gatling/gatling-recorder]]]
-  :profiles {:dev {:dependencies [[clj-containment-matchers "1.0.1"]] }})
+  :profiles {:dev {:dependencies [[clj-containment-matchers "1.0.1"]]}})

--- a/src/clojider_gatling_highcharts_reporter/core.clj
+++ b/src/clojider_gatling_highcharts_reporter/core.clj
@@ -12,7 +12,7 @@
   (LocalDateTime/now))
 
 (defn create-dir [dir]
-  (.mkdirs (File. dir)))
+  (.mkdirs (File. ^String dir)))
 
 (defn gatling-highcharts-reporter [results-dir]
   (let [input-dir (path-join results-dir "input")]
@@ -21,4 +21,4 @@
      :generator (fn [_]
                   (println "Creating report from files in" results-dir)
                   (create-chart results-dir)
-                  (println (str "Open " results-dir "/index.html with your browser to see a detailed report." )))}))
+                  (println (str "Open " results-dir "/index.html with your browser to see a detailed report.")))}))

--- a/src/clojider_gatling_highcharts_reporter/reporter.clj
+++ b/src/clojider_gatling_highcharts_reporter/reporter.clj
@@ -13,8 +13,12 @@
         request-end start
         response-start end
         execution-end end
-        result (if (:result request) "OK" "KO")]
-    [scenario-name id "REQUEST" "" (:name request) execution-start request-end response-start execution-end result "\u0020"]))
+        result (if (:result request) "OK" "KO")
+        exception (:exception request)
+        vec-prefix [scenario-name id "REQUEST" "" (:name request) execution-start request-end response-start execution-end result]]
+    (if exception
+      (conj vec-prefix exception "\u0020")
+      (conj vec-prefix "\u0020"))))
 
 (defn- scenario->rows [scenario]
   (let [start (str (:start scenario))


### PR DESCRIPTION
The Gatling Highcharts bundle log is able to include an extra message
about the failure cause in the case of KO responses. This allows the
bundle to group failures by message, so you can see there were X
timeouts, Y 401s etc.

The most normal case for these is to pass around an exception that has
been thrown, so this change sets the message to the stringified
exception if one is present in the result. In the case of Java
exceptions, this is `exception.Class: Exception message`. A stringified
`clojure.lang.ExceptionInfo` includes the data supplied, which could be
very large, so we specifically exclude that and only output the class
and message, to match normal Java exceptions.